### PR TITLE
PIMPRED-50, добавил версионирование для спрайта для обновления кэша

### DIFF
--- a/development/less/mixins/@images.less
+++ b/development/less/mixins/@images.less
@@ -8,7 +8,7 @@
 @img-sprite-form_37x35: '@{img-sprites}/sprite__form-icos_37x35.png';
 @img-sprite-form_50x48: '@{img-sprites}/sprite__form-icos_50x48.png';
 
-@img-sprite-pcard: '@{img-sprites}/pcard_icos_sprite.png';
+@img-sprite-pcard: '@{img-sprites}/pcard_icos_sprite.png?v170727';
 @img-sprite-pcard_mob: '@{img-sprites}/pcard_icos_sprite__mob.png';
 @img-sprite-pcard-order: '@{img-sprites}/pcard_order_sprite.png';
 


### PR DESCRIPTION
@img-sprite-pcard: '@{img-sprites}/pcard_icos_sprite.png?v170727';